### PR TITLE
可以使用用户指定的配置

### DIFF
--- a/src/CosStorageServiceProvider.php
+++ b/src/CosStorageServiceProvider.php
@@ -15,8 +15,8 @@ class CosStorageServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Storage::extend('cos', function () {
-            $adapter = new CosAdapter(\config('filesystems.disks.cos'));
+        Storage::extend('cos', function ($app, $config) {
+            $adapter = new CosAdapter($config);
 
             return new FilesystemAdapter(new Filesystem($adapter), $adapter);
         });


### PR DESCRIPTION
通过指定不同的配置来使用多个对象存储，不再只读取filesystems.disks.cos中的配置，例如：
```php
Storage::disk('cos-1')  
Storage::disk('cos-2')
```
